### PR TITLE
hw/virtio-gpu: Cursor size can be changed

### DIFF
--- a/hw/display/virtio-gpu.c
+++ b/hw/display/virtio-gpu.c
@@ -57,9 +57,14 @@ void virtio_gpu_update_cursor_data(VirtIOGPU *g,
     }
 
     if (res->blob_size) {
-        if (res->blob_size < (s->current_cursor->width *
-                              s->current_cursor->height * 4)) {
-            return;
+        if (res->blob_size != (s->current_cursor->width *
+                               s->current_cursor->height * 4)) {
+            /* resize 'current_cursor' for the new blob_size
+             * The assumption is the cursor image is square.
+             */
+            int width = sqrt(res->blob_size / 4);
+            g_free(s->current_cursor);
+            s->current_cursor = cursor_alloc(width, width);
         }
         data = res->blob;
     } else if (res->image) {

--- a/include/qemu/osdep.h
+++ b/include/qemu/osdep.h
@@ -121,6 +121,7 @@ QEMU_EXTERN_C int daemon(int, int);
  * function availability on recentish Mingw-w64 platforms. */
 #include <unistd.h>
 #include <time.h>
+#include <math.h>
 #include <ctype.h>
 #include <errno.h>
 #include <fcntl.h>


### PR DESCRIPTION
HW cursor image size is set to 128, 128 in windows guest (using ZC driver). QEMU should be able to resize (via reallocation) the container of guest mouse cursor to accomodate this new size.